### PR TITLE
Gatsby2 Api update

### DIFF
--- a/src/gatsby-browser.js
+++ b/src/gatsby-browser.js
@@ -21,12 +21,9 @@ exports.onRouteUpdate = ({ location }, pluginOptions) => {
   const options = getOptions(pluginOptions);
 
   if (!isEnable(options)) {
-    mixpanel.init('disable', { autotrack: false });
-    mixpanel.disable();
     return;
   }
 
-  mixpanel.init(options.apiToken, { debug: options.debug });
   if (options.pageViews) {
     const mixpanelEvent = options.pageViews[location.pathname];
     if (mixpanelEvent) {
@@ -34,6 +31,18 @@ exports.onRouteUpdate = ({ location }, pluginOptions) => {
     }
   }
 };
+
+exports.onClientEntry = (skip, pluginOptions) => {
+  const options = getOptions(pluginOptions);
+
+  if (!isEnable(options)) {
+    mixpanel.init('disable', { autotrack: false });
+    mixpanel.disable();
+    return;
+  }
+
+  mixpanel.init(options.apiToken, { debug: options.debug });
+}
 
 exports.wrapPageElement = ({ element }) => {
   return (


### PR DESCRIPTION
@thomascarvalho Hi! Have issue when call this.context.mixpanel.track in layout component componentDidMount because onRouteUpdate is delayed and init mixpanel later. 
Move mixpanel init into onClientEntry has fixed this problem and optimize double inits when page transitions.