### PR TITLE
disable initial track on page load

### DIFF
--- a/src/gatsby-browser.js
+++ b/src/gatsby-browser.js
@@ -52,7 +52,7 @@ exports.onClientEntry = (skip, pluginOptions) => {
     return;
   }
 
-  mixpanel.init(options.apiToken, { debug: options.debug });
+  mixpanel.init(options.apiToken, { debug: options.debug, track_pageview: false });
 }
 
 exports.wrapPageElement = ({ element }) => {


### PR DESCRIPTION
Hi @thomascarvalho  :) 

It seems that latest mixpanel lib do a track on page load which colide with pageViews settings and all,

let's remove it :)

