### PR TITLE
Add ability to transform page view event before sending to mixpanel

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,8 @@ plugins: [
       mixpanelConfig: null // override specific config for mixpanel initialization https://github.com/mixpanel/mixpanel-js/blob/8b2e1f7b/src/mixpanel-core.js#L87-L110
       pageViews: null, // see below
        // set pageViews to 'all' and use this option to set the same event name for all page view events
-      trackPageViewsAs: null, // optionaly: set an Event Name to use for all page views, eg: trackPageViewsAs: 'Page view'
+      trackPageViewsAs: null, // optionally: set an Event Name to use for all page views, eg: trackPageViewsAs: 'Page view'
+      getPageViewTransformerFn: null, // optionally: function body as a string to customize the event sent to mixpanel. Receives one parameter: location. Example 'return () => ({url: location.pathname})'
     },
   },
 ];

--- a/src/gatsby-browser.js
+++ b/src/gatsby-browser.js
@@ -44,7 +44,7 @@ function getOptions(pluginOptions) {
     enableOnDevMode: true,
     mixpanelConfig: null,
     trackPageViewsAs: null,
-    getPageViewTransformerFn: 'return event',
+    getPageViewTransformerFn: 'return function(location) { return location; }',
   };
 
   const options = { ...defaultsOptions, ...pluginOptions };
@@ -62,7 +62,7 @@ exports.onRouteUpdate = ({ location }, pluginOptions) => {
     location,
     options.pageViews,
     options.trackPageViewsAs,
-    options.pageViewEventTransformer,
+    options.getPageViewTransformerFn,
   );
 };
 

--- a/src/gatsby-browser.js
+++ b/src/gatsby-browser.js
@@ -13,17 +13,28 @@ function trackEvent(eventName, properties) {
   if (eventName) mixpanel.track(eventName, properties)
 }
 
-function trackPageViews(location, pageViews, trackPageViewsAs) {
+function trackPageViews(
+  location,
+  pageViews,
+  trackPageViewsAs,
+  getPageViewTransformerFn,
+) {
   if (pageViews && location) {
-    let eventName
+    let eventName;
     if (pageViews instanceof Object) {
-      eventName = pageViews[location.pathname]
+      eventName = pageViews[location.pathname];
     } else if (trackPageViewsAs) {
-      eventName = trackPageViewsAs
+      eventName = trackPageViewsAs;
     } else if (pageViews === 'all') {
-      eventName = `View page ${location.pathname}`
+      eventName = `View page ${location.pathname}`;
     }
-    trackEvent(eventName, location)
+
+    const pageViewEventTransformerFn = new Function(
+      'location',
+      getPageViewTransformerFn,
+    );
+    const event = pageViewEventTransformerFn()(location);
+    trackEvent(eventName, event);
   }
 }
 
@@ -33,9 +44,11 @@ function getOptions(pluginOptions) {
     enableOnDevMode: true,
     mixpanelConfig: null,
     trackPageViewsAs: null,
-  }
-  const options = { ...defaultsOptions, ...pluginOptions }
-  return { ...options, isEnable: isEnable(options) }
+    getPageViewTransformerFn: 'return event',
+  };
+
+  const options = { ...defaultsOptions, ...pluginOptions };
+  return { ...options, isEnable: isEnable(options) };
 }
 
 exports.onRouteUpdate = ({ location }, pluginOptions) => {
@@ -45,8 +58,13 @@ exports.onRouteUpdate = ({ location }, pluginOptions) => {
     return
   }
 
-  trackPageViews(location, options.pageViews, options.trackPageViewsAs)
-}
+  trackPageViews(
+    location,
+    options.pageViews,
+    options.trackPageViewsAs,
+    options.pageViewEventTransformer,
+  );
+};
 
 exports.onClientEntry = (skip, pluginOptions) => {
   const options = getOptions(pluginOptions)


### PR DESCRIPTION
I forked this repo because I needed the ability to transform my page_view event before sending it to mixpanel.

It was a little trickier than I thought because Gatsby for `gatsby-browser.js` stringify's the options so I couldn't just pass a transformer function.

For this I used the `Function` class.

The default is a noop transform. Attached is a more complex example. 

In the attached example we transform location into an object of the shape:

```javascript
{
  url: string,
  screenName: string,
}
```

```javascript
//gatsby-config.js

module.exports = {
  siteMetadata: {
    siteName: `Truzen`,
    title: 'Find a top rated local massage therapist',
    description:
      'Truzen helps you find and book a top rated certified massage therapist near you in minutes.',
    siteUrl: `https://truzen.com`,
    image: '/images/feature-graphic.jpg',
    twitterUsername: `@findTruzen`,
    titleTemplate: 'Truzen - %s',
  },
  plugins: [
    {
      resolve: 'gatsby-plugin-mixpanel',
      options: {
        apiToken: environment.mixpanelToken, // required
        trackPageViewsAs: 'page_view',
        pageViews: 'all',
        enableOnDevMode: true,
        getPageViewTransformerFn: `return ${(location => {
          const pathname = location.pathname || '';
          const currentScreen = pathname.startsWith('/blog')
            ? 'BlogPage'
            : pathname.startsWith('/legal')
            ? 'LegalPage'
            : pathname === '/'
            ? 'HomePage'
            : null;

          return {
            url: pathname,
            currentScreen,
          };
        }).toString()};`,
      },
    },
  ],
};

```