### PR TITLE
Upgrade Gatsby to 4.13.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "gatsby-plugin-mixpanel",
   "description": "Gatsby plugin to add mixpanel",
-  "version": "3.5.0",
+  "version": "3.5.1",
   "author": "Thomas Carvalho <carvalho.thomas@gmail.com>",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "mixpanel-browser": "^2.41.0"
   },
   "peerDependencies": {
-    "gatsby": "^3.0.0",
+    "gatsby": "^4.13.1",
     "react": "^16.9.0 || ^17.0.0",
     "react-dom": "^16.9.0 || ^17.0.0"
   }


### PR DESCRIPTION
Hi @thomascarvalho, we're using your plugin in our project and we would like to upgrade Gatsby to version 4.x. We've tested it and it works for Gatsby 4 without any issue.